### PR TITLE
Enable --try-add-blocked-jobs by default

### DIFF
--- a/jade/cli/submit_jobs.py
+++ b/jade/cli/submit_jobs.py
@@ -104,10 +104,10 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--try-add-blocked-jobs/--no-try-add-blocked-jobs",
     is_flag=True,
-    default=False,
+    default=True,
     show_default=True,
-    help="Add blocked jobs to HPC batch if they are blocked by jobs already "
-         "in batch."
+    help="Add blocked jobs to a node's batch if they are blocked by jobs "
+         "already in the batch."
 )
 def submit_jobs(
         config_file, per_node_batch_size, hpc_config, local, max_nodes,


### PR DESCRIPTION
This changes the default behavior to add blocked jobs to a node's batch
if the blocking jobs are already part of that batch.

This is likely the expected behavior from users. It will enable the
workflow where each batch has one aggregation script to upload all data
written to a node's local storage by the main jobs.

@jgu2 Can you think of any reason not to do this? Will it cause any problems for your disco upgrade extension?