### PR TITLE
Support multiple extensions in one configuration

### DIFF
--- a/jade/cli/config.py
+++ b/jade/cli/config.py
@@ -68,7 +68,6 @@ def show(config_file, fields):
 def _show(config_file, fields):
     cfg = load_data(config_file)
     jobs = cfg["jobs"]
-    print(f"Extension: {cfg['extension']}")
     print(f"Num jobs: {len(cfg['jobs'])}")
     if not jobs:
         return

--- a/jade/common.py
+++ b/jade/common.py
@@ -13,24 +13,20 @@ ANALYSIS_DIR = "analysis"
 POST_PROCESSING_CONFIG_FILE = "post-config.json"
 
 
-def get_results_temp_filename(output_dir, batch_id):
-    """Get the results temp filename for a batch of jobs.
+def get_results_filename(output_dir):
+    """Get the results filename for all jobs.
 
     Parameters
     ----------
     output_dir : str
         output directory for all jobs
-    batch_id : int
-        batch ID of jobs running on a node
 
     Returns
     -------
     str
 
     """
-    # This uses CSV files because it allows for cheap appends by jobs.
+    # This uses a CSV file because it allows for cheap appends by jobs.
     # For JSON and TOML each job would have to parse all existing jobs before
     # appending.
-    return os.path.join(
-        output_dir, RESULTS_DIR, f"results_batch_{batch_id}.csv"
-    )
+    return os.path.join(output_dir, f"results.csv")

--- a/jade/extensions/demo/autoregression_configuration.py
+++ b/jade/extensions/demo/autoregression_configuration.py
@@ -11,35 +11,8 @@ class AutoRegressionConfiguration(JobConfiguration):
     A class used to configure auto-regression jobs
     """
 
-    def __init__(self, job_inputs, **kwargs):
-        """
-        Init AutoRegression class
-
-        Parameters
-        ----------
-        job_inputs: :obj:`AutoRegressionInputs`
-            The instance of :obj:`AutoRegressionInputs`
-        kwargs, extra arguments
-        """
-
-        super(AutoRegressionConfiguration, self).__init__(
-            inputs=job_inputs,
-            container=JobContainerByKey(),
-            job_parameters_class=AutoRegressionParameters,
-            extension_name="demo",
-            **kwargs
-        )
-
     def _serialize(self, data):
-        """Fill in instance-specific information."""
-
-    def _transform_for_local_execution(self, scratch_dir, are_inputs_local):
-        """Transform data for efficient execution"""
+        pass
 
     def create_from_result(self, job, output_dir):
-        """Create instance from result"""
         return None
-
-    def get_job_inputs(self):
-        """Get the instance of :obj:`JobInputs`"""
-        return self._inputs

--- a/jade/extensions/demo/autoregression_parameters.py
+++ b/jade/extensions/demo/autoregression_parameters.py
@@ -11,6 +11,7 @@ class AutoRegressionParameters(JobParametersInterface):
     """
 
     parameters_type = namedtuple("AutoRegression", "country")
+    _EXTENSION = "demo"
 
     def __init__(self, country, data):
         """
@@ -31,6 +32,10 @@ class AutoRegressionParameters(JobParametersInterface):
         return "<AutoRegressionParameters: {}>".format(self.name)
 
     @property
+    def extension(self):
+        return self._EXTENSION
+
+    @property
     def name(self):
         return self._name
 
@@ -40,7 +45,8 @@ class AutoRegressionParameters(JobParametersInterface):
     def serialize(self):
         return {
             "country": self._name,
-            "data": self.data
+            "data": self.data,
+            "extension": self.extension,
         }
 
     @classmethod

--- a/jade/extensions/demo/cli.py
+++ b/jade/extensions/demo/cli.py
@@ -20,8 +20,8 @@ def auto_config(inputs, **kwargs):
         raise OSError(f"Inputs path '{inputs}' does not exist.")
 
     job_inputs = AutoRegressionInputs(inputs)
-    config = AutoRegressionConfiguration(job_inputs=job_inputs, **kwargs)
-    for job_param in config.inputs.iter_jobs():
+    config = AutoRegressionConfiguration(**kwargs)
+    for job_param in job_inputs.iter_jobs():
         config.add_job(job_param)
 
     return config

--- a/jade/extensions/generic_command/generic_command_configuration.py
+++ b/jade/extensions/generic_command/generic_command_configuration.py
@@ -11,41 +11,32 @@ from jade.extensions.generic_command.generic_command_parameters import \
 class GenericCommandConfiguration(JobConfiguration):
     """A class used to configure generic_command jobs."""
 
-    def __init__(self, job_inputs, **kwargs):
+    def __init__(self, **kwargs):
         """
         Init GenericCommand class
 
         Parameters
         ----------
-        job_inputs: :obj:`GenericCommandInputs`
-            The instance of :obj:`GenericCommandInputs`
         kwargs, extra arguments
+
         """
         self._cur_job_id = 1
-        super(GenericCommandConfiguration, self).__init__(
-            inputs=job_inputs,
-            container=JobContainerByKey(),
-            job_parameters_class=GenericCommandParameters,
-            extension_name="generic_command",
-            **kwargs
-        )
+        super(GenericCommandConfiguration, self).__init__(**kwargs)
 
     @classmethod
     def auto_config(cls, inputs, **kwargs):
         """Create a configuration from all available inputs."""
         if isinstance(inputs, str):
-            job_inputs = GenericCommandInputs(inputs)
-        else:
-            job_inputs = inputs
+            inputs = GenericCommandInputs(inputs)
 
-        config = GenericCommandConfiguration(job_inputs, **kwargs)
-        for job_param in config.inputs.iter_jobs():
+        config = GenericCommandConfiguration(**kwargs)
+        for job_param in inputs.iter_jobs():
             config.add_job(job_param)
 
         return config
 
     def _serialize(self, data):
-        """Fill in instance-specific information."""
+        pass
 
     def add_job(self, job):
         # Overrides JobConfiguration.add_job so that it can add a unique
@@ -60,6 +51,3 @@ class GenericCommandConfiguration(JobConfiguration):
 
     def create_from_result(self, job, output_dir):
         return None
-
-    def get_job_inputs(self):
-        return self._inputs

--- a/jade/extensions/generic_command/generic_command_execution.py
+++ b/jade/extensions/generic_command/generic_command_execution.py
@@ -36,7 +36,7 @@ class GenericCommandExecution(JobExecutionInterface):
     def generate_command(job, output, config_file, verbose=False):
         # These jobs already have a command and are not run with jade-internal.
         if job.append_output_dir:
-            return job.command + f" --output={output}"
+            return job.command + f" --jade-runtime-output={output}"
         return job.command
 
     def list_results_files(self):

--- a/jade/extensions/generic_command/generic_command_execution.py
+++ b/jade/extensions/generic_command/generic_command_execution.py
@@ -35,6 +35,8 @@ class GenericCommandExecution(JobExecutionInterface):
     @staticmethod
     def generate_command(job, output, config_file, verbose=False):
         # These jobs already have a command and are not run with jade-internal.
+        if job.append_output_dir:
+            return job.command + f" --output={output}"
         return job.command
 
     def list_results_files(self):

--- a/jade/extensions/generic_command/generic_command_execution.py
+++ b/jade/extensions/generic_command/generic_command_execution.py
@@ -1,6 +1,7 @@
 """The job execution class and methods for generic_command."""
 
 import logging
+import os
 
 from jade.jobs.job_execution_interface import JobExecutionInterface
 
@@ -36,7 +37,9 @@ class GenericCommandExecution(JobExecutionInterface):
     def generate_command(job, output, config_file, verbose=False):
         # These jobs already have a command and are not run with jade-internal.
         if job.append_output_dir:
-            return job.command + f" --jade-runtime-output={output}"
+            # output is jobs-output
+            output_dir = os.path.dirname(output)
+            return job.command + f" --jade-runtime-output={output_dir}"
         return job.command
 
     def list_results_files(self):

--- a/jade/extensions/generic_command/generic_command_parameters.py
+++ b/jade/extensions/generic_command/generic_command_parameters.py
@@ -10,7 +10,7 @@ class GenericCommandParameters(JobParametersInterface):
     parameters_type = namedtuple("GenericCommand", "command")
     _EXTENSION = "generic_command"
 
-    def __init__(self, command, job_id=None,  blocked_by=None):
+    def __init__(self, command, job_id=None, blocked_by=None, append_output_dir=False):
         self.command = command
         self.job_id = job_id  # Gets set when job is added to config.
                               # Uniquely identifies the job.
@@ -18,6 +18,10 @@ class GenericCommandParameters(JobParametersInterface):
         if blocked_by is not None:
             for job_id in blocked_by:
                 self.blocked_by.add(str(job_id))
+
+        # Indicates whether the output directory should be appended to the
+        # command at runtime.
+        self.append_output_dir = append_output_dir
 
     def __str__(self):
         return "<GenericCommandParameters: {}>".format(self.name)
@@ -40,6 +44,7 @@ class GenericCommandParameters(JobParametersInterface):
             "job_id": self.job_id,
             "blocked_by": list(self.blocked_by),
             "extension": self.extension,
+            "append_output_dir": self.append_output_dir,
         }
 
     @classmethod
@@ -48,6 +53,7 @@ class GenericCommandParameters(JobParametersInterface):
             data["command"],
             job_id=data["job_id"],
             blocked_by={str(x) for x in data["blocked_by"]},
+            append_output_dir=data["append_output_dir"],
         )
 
     def get_blocking_jobs(self):

--- a/jade/extensions/generic_command/generic_command_parameters.py
+++ b/jade/extensions/generic_command/generic_command_parameters.py
@@ -8,6 +8,7 @@ class GenericCommandParameters(JobParametersInterface):
     """A class used for creating a job for a generic command."""
 
     parameters_type = namedtuple("GenericCommand", "command")
+    _EXTENSION = "generic_command"
 
     def __init__(self, command, job_id=None,  blocked_by=None):
         self.command = command
@@ -22,6 +23,10 @@ class GenericCommandParameters(JobParametersInterface):
         return "<GenericCommandParameters: {}>".format(self.name)
 
     @property
+    def extension(self):
+        return self._EXTENSION
+
+    @property
     def name(self):
         return self._create_name()
 
@@ -34,6 +39,7 @@ class GenericCommandParameters(JobParametersInterface):
             "command": self.command,
             "job_id": self.job_id,
             "blocked_by": list(self.blocked_by),
+            "extension": self.extension,
         }
 
     @classmethod

--- a/jade/jobs/dispatchable_job.py
+++ b/jade/jobs/dispatchable_job.py
@@ -39,11 +39,6 @@ class DispatchableJob(DispatchableJobInterface):
         ret = self._pipe.returncode
         exec_time_s = time.time() - self._start_time
 
-        job_filename = self._job.name
-        illegal_chars = ("/", "\\", ":")
-        for char in illegal_chars:
-            job_filename = job_filename.replace(char, "-")
-
         status = "finished"
         output_dir = os.path.join(self._output, JOBS_OUTPUT_DIR, self._job.name)
         bytes_consumed = get_directory_size_bytes(output_dir)

--- a/jade/jobs/job_configuration.py
+++ b/jade/jobs/job_configuration.py
@@ -12,6 +12,7 @@ import toml
 from jade.common import CONFIG_FILE
 from jade.exceptions import InvalidConfiguration, InvalidParameter
 from jade.extensions.registry import Registry, ExtensionClassType
+from jade.jobs.job_container_by_key import JobContainerByKey
 from jade.utils.utils import dump_data, load_data, ExtendedJSONEncoder
 from jade.utils.timing_utils import timed_debug
 
@@ -30,16 +31,13 @@ class JobConfiguration(abc.ABC):
     """Base class for any simulation configuration."""
 
     FILENAME_DELIMITER = "_"
+    FORMAT_VERSION = "v0.2.0"
 
     def __init__(
             self,
-            inputs,
-            container,
-            job_parameters_class,
-            extension_name,
+            container=None,
             job_global_config=None,
             job_post_process_config=None,
-            batch_post_process_config=None,
             **kwargs
         ):
         """
@@ -51,16 +49,12 @@ class JobConfiguration(abc.ABC):
         container : JobContainerInterface
 
         """
-        self._extension_name = extension_name
-        self._inputs = inputs
-        self._jobs = container
-        self._job_parameters_class = job_parameters_class
+        self._jobs = container or JobContainerByKey()
         self._job_names = None
         self._jobs_directory = kwargs.get("jobs_directory")
         self._registry = Registry()
         self._job_global_config = job_global_config
         self._job_post_process_config = job_post_process_config
-        self._batch_post_process_config = batch_post_process_config
 
         if kwargs.get("do_not_deserialize_jobs", False):
             assert "job_names" in kwargs, str(kwargs)
@@ -79,8 +73,9 @@ class JobConfiguration(abc.ABC):
         return self.dumps()
 
     def _deserialize_jobs(self, jobs):
-        for job_ in jobs:
-            job = self._job_parameters_class.deserialize(job_)
+        for _job in jobs:
+            param_class = self.job_parameters_class(_job["extension"])
+            job = param_class.deserialize(_job)
             self.add_job(job)
 
     def _deserialize_jobs_from_names(self, job_names):
@@ -103,7 +98,9 @@ class JobConfiguration(abc.ABC):
         assert self._jobs_directory is not None
         filename = os.path.join(self._jobs_directory, name) + ".json"
         assert os.path.exists(filename), filename
-        return self._job_parameters_class.deserialize(load_data(filename))
+        job = load_data(filename)
+        param_class = self.job_parameters_class(job["extension"])
+        return param_class.deserialize(job)
 
     @abc.abstractmethod
     def _serialize(self, data):
@@ -147,15 +144,6 @@ class JobConfiguration(abc.ABC):
         class
 
         """
-
-    @property
-    def extension_name(self):
-        """Return the extension name for the configuration."""
-        return self._extension_name
-
-    @abc.abstractmethod
-    def get_job_inputs(self):
-        """Return the inputs required to run a job."""
 
     def add_job(self, job):
         """Add a job to the configuration.
@@ -238,13 +226,8 @@ class JobConfiguration(abc.ABC):
         else:
             data = filename_or_data
 
-        # Don't create an inputs object. It can be very expensive and we don't
-        # need it unless the user wants to change the config.
-        # TODO: implement user-friendly error messages when they try to access
-        # inputs.
-        inputs = None
         data["do_not_deserialize_jobs"] = do_not_deserialize_jobs
-        return cls(inputs, **data)
+        return cls(**data)
 
     def get_job(self, name):
         """Return the job matching name.
@@ -260,10 +243,6 @@ class JobConfiguration(abc.ABC):
 
         return self._jobs.get_job(name)
 
-    def get_parameters_class(self):
-        """Return the class used for job parameters."""
-        return self._job_parameters_class
-
     def get_num_jobs(self):
         """Return the number of jobs in the configuration.
 
@@ -278,25 +257,6 @@ class JobConfiguration(abc.ABC):
     def job_global_config(self):
         """Return the global configs applied to all jobs."""
         return self._job_global_config
-
-    @property
-    def job_post_process_config(self):
-        """Return post process config for jobs"""
-        return self._job_post_process_config
-
-    @property
-    def batch_post_process_config(self):
-        """Return batch post process config for task"""
-        return self._batch_post_process_config
-
-    @batch_post_process_config.setter
-    def batch_post_process_config(self, data):
-        self._batch_post_process_config = data
-
-    @property
-    def inputs(self):
-        """Return the instance of JobInputsInterface for the job."""
-        return self._inputs
 
     def iter_jobs(self):
         """Yields a generator over all jobs.
@@ -346,40 +306,19 @@ class JobConfiguration(abc.ABC):
         """
         return self._jobs.remove_job(job)
 
-    def run_job(self, job, output, **kwargs):
-        """Run the job.
-
-        Parameters
-        ----------
-        job : JobParametersInterface
-        output : str
-            output directory
-
-        Returns
-        -------
-        int
-
-        """
-        logger.debug("job=%s kwargs=%s", job, kwargs)
-        cls = self.job_execution_class()
-        job_execution = cls.create(self.get_job_inputs(), job, output)
-        return job_execution.run(**kwargs)
-
     def serialize(self, include=ConfigSerializeOptions.JOBS):
         """Create data for serialization."""
         data = {
-            "class": self.__class__.__name__,
-            "extension": self.extension_name,
             "jobs_directory": self._jobs_directory,
+            "configuration_module": self.__class__.__module__,
+            "configuration_class": self.__class__.__name__,
+            "format_version": self.FORMAT_VERSION
         }
         if self._job_global_config:
             data["job_global_config"] = self._job_global_config
 
         if self._job_post_process_config:
             data["job_post_process_config"] = self._job_post_process_config
-
-        if self._batch_post_process_config:
-            data["batch_post_process_config"] = self._batch_post_process_config
 
         if include == ConfigSerializeOptions.JOBS:
             data["jobs"] = [x.serialize() for x in self.iter_jobs()]
@@ -450,13 +389,34 @@ class JobConfiguration(abc.ABC):
         for job in self.iter_jobs():
             print(job)
 
-    def job_execution_class(self):
+    def job_execution_class(self, extension_name):
         """Return the class used for job execution.
+
+        Parameters
+        ----------
+        extension_name : str
 
         Returns
         -------
         class
 
         """
-        return self._registry.get_extension_class(self.extension_name,
+        return self._registry.get_extension_class(extension_name,
                                                   ExtensionClassType.EXECUTION)
+
+    def job_parameters_class(self, extension_name):
+        """Return the class used for job parameters.
+
+        Parameters
+        ----------
+        extension_name : str
+
+        Returns
+        -------
+        class
+
+        """
+        return self._registry.get_extension_class(
+            extension_name,
+            ExtensionClassType.PARAMETERS
+        )

--- a/jade/jobs/job_configuration_factory.py
+++ b/jade/jobs/job_configuration_factory.py
@@ -116,5 +116,6 @@ def upgrade_config_file(data, filename):
     data.pop("extension")
     for job in data["jobs"]:
         job["extension"] = "generic_command"
+        job["append_output_dir"] = False
     dump_data(data, filename, indent=2)
     logger.info("Upgraded config file format: %s", filename)

--- a/jade/jobs/job_container_by_key.py
+++ b/jade/jobs/job_container_by_key.py
@@ -68,5 +68,13 @@ class JobContainerByKey(JobContainerInterface):
 
         return job
 
+    def get_jobs(self, sort_by_key=False):
+        if sort_by_key:
+            keys = list(self._jobs.keys())
+            keys.sort()
+            return [self._jobs[x] for x in keys]
+
+        return list(self.iter_jobs)
+
     def get_num_jobs(self):
         return len(self._jobs)

--- a/jade/jobs/job_container_interface.py
+++ b/jade/jobs/job_container_interface.py
@@ -3,7 +3,7 @@
 import abc
 
 
-class JobContainerInterface:
+class JobContainerInterface(abc.ABC):
     """Defines interface for job containers."""
 
     @abc.abstractmethod

--- a/jade/jobs/job_parameters_interface.py
+++ b/jade/jobs/job_parameters_interface.py
@@ -10,6 +10,17 @@ class JobParametersInterface:
 
     @property
     @abc.abstractmethod
+    def extension(self):
+        """Return the extension name.
+
+        Returns
+        -------
+        str
+
+        """
+
+    @property
+    @abc.abstractmethod
     def name(self):
         """Return the job name. The job name must be unique in a configuration
         and must be usable as a directory or file name on any filesystem.

--- a/jade/jobs/job_runner.py
+++ b/jade/jobs/job_runner.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import uuid
 
-from jade.common import JOBS_OUTPUT_DIR, OUTPUT_DIR, get_results_temp_filename
+from jade.common import JOBS_OUTPUT_DIR, OUTPUT_DIR, get_results_filename
 from jade.enums import Status
 from jade.hpc.common import HpcType
 from jade.hpc.local_manager import LocalManager
@@ -111,11 +111,7 @@ class JobRunner(JobManagerBase):
         return intf, intf_type
 
     def _generate_jobs(self, config_file, verbose):
-        results_filename = get_results_temp_filename(
-            self._output, self._batch_id
-        )
-        results_aggregator = ResultsAggregator(results_filename)
-        results_aggregator.create_file()
+        results_filename = get_results_filename(self._output)
 
         jobs = []
         for job in self._config.iter_jobs():

--- a/jade/jobs/job_runner.py
+++ b/jade/jobs/job_runner.py
@@ -111,22 +111,29 @@ class JobRunner(JobManagerBase):
         return intf, intf_type
 
     def _generate_jobs(self, config_file, verbose):
-        job_exec_class = self._config.job_execution_class()
         results_filename = get_results_temp_filename(
             self._output, self._batch_id
         )
         results_aggregator = ResultsAggregator(results_filename)
         results_aggregator.create_file()
 
-        return [
-            DispatchableJob(
+        jobs = []
+        for job in self._config.iter_jobs():
+            job_exec_class = self._config.job_execution_class(job.extension)
+            djob = DispatchableJob(
                 job,
                 job_exec_class.generate_command(
-                    job, self._jobs_output, config_file, verbose=verbose),
+                    job,
+                    self._jobs_output,
+                    config_file,
+                    verbose=verbose,
+                ),
                 self._output,
-                results_filename
-            ) for job in self._config.iter_jobs()
-        ]
+                results_filename,
+            )
+            jobs.append(djob)
+
+        return jobs
 
     def _run_jobs(self, jobs, num_processes=None):
         num_jobs = len(jobs)

--- a/jade/jobs/job_submitter.py
+++ b/jade/jobs/job_submitter.py
@@ -208,9 +208,6 @@ results_summary={self.get_results_summmary_report()}"""
         results = self._build_results()
         data["results_summary"] = results["summary"]
         data["results"] = results["results"]
-        data["job_outputs"] = \
-            self._config.job_execution_class().collect_results(
-                os.path.join(self._output, JOBS_OUTPUT_DIR))
 
         output_file = os.path.join(self._output, filename)
         dump_data(data, output_file)

--- a/jade/result.py
+++ b/jade/result.py
@@ -103,6 +103,7 @@ class ResultsSummary:
         self._output_dir = output_dir
 
         self._results_file = os.path.join(output_dir, RESULTS_FILE)
+
         data = self._parse(self._results_file)
         data["results"] = deserialize_results(data["results"])
         self._results = data

--- a/jade/utils/utils.py
+++ b/jade/utils/utils.py
@@ -1,7 +1,7 @@
 """Utility functions for the jade package."""
 
 from datetime import datetime, date
-from pathlib import PosixPath
+from pathlib import PosixPath, WindowsPath
 from typing import Union
 import enum
 import functools
@@ -498,7 +498,7 @@ class ExtendedJSONEncoder(json.JSONEncoder):
         if isinstance(obj, enum.Enum):
             return obj.value
 
-        if isinstance(obj, PosixPath):
+        if isinstance(obj, PosixPath) or isinstance(obj, WindowsPath):
             return str(obj)
 
         if isinstance(obj, (datetime, date)):

--- a/tests/data/demo/test-config.json
+++ b/tests/data/demo/test-config.json
@@ -1,19 +1,23 @@
 {
-  "class": "AutoRegressionConfiguration",
-  "extension": "demo",
   "jobs_directory": null,
+  "format_version": "v0.2.0",
+  "configuration_module": "jade.extensions.demo.autoregression_configuration",
+  "configuration_class": "AutoRegressionConfiguration",
   "jobs": [
     {
       "country": "australia",
-      "data": "demo/gdp/countries/australia.csv"
+      "data": "demo/gdp/countries/australia.csv",
+      "extension": "demo"
     },
     {
       "country": "brazil",
-      "data": "demo/gdp/countries/brazil.csv"
+      "data": "demo/gdp/countries/brazil.csv",
+      "extension": "demo"
     },
     {
       "country": "united_states",
-      "data": "demo/gdp/countries/united_states.csv"
+      "data": "demo/gdp/countries/united_states.csv",
+      "extension": "demo"
     }
   ]
 }

--- a/tests/unit/extensions/demo/test_autoregression_configuration.py
+++ b/tests/unit/extensions/demo/test_autoregression_configuration.py
@@ -12,14 +12,13 @@ from jade.exceptions import InvalidParameter
 from jade.extensions.demo.autoregression_configuration import AutoRegressionConfiguration
 from jade.extensions.demo.autoregression_execution import AutoRegressionExecution
 from jade.extensions.demo.autoregression_parameters import AutoRegressionParameters
+from jade.jobs.job_configuration import JobConfiguration
 
 
 def test_init():
     """Should return expected attributes after initialization"""
     job_inputs = MagicMock()
     arc = AutoRegressionConfiguration(job_inputs=job_inputs)
-    assert arc.inputs == job_inputs
-    assert arc.job_execution_class() == AutoRegressionExecution
 
 
 def test_create_from_result():
@@ -31,20 +30,9 @@ def test_create_from_result():
     assert arc.create_from_result(MagicMock(), "output") is None
 
 
-def test_get_job_inputs():
-    """Test class methods"""
-    job_inputs = MagicMock()
-    arc = AutoRegressionConfiguration(
-        job_inputs=job_inputs,
-    )
-    assert arc.get_job_inputs() == job_inputs
-
-
 def test_autogression_configuration__add_job():
     """Should add job to container"""
-    arc = AutoRegressionConfiguration(
-        job_inputs=MagicMock(),
-    )
+    arc = AutoRegressionConfiguration()
     job1 = MagicMock()
     job1.name = "test"
     arc.add_job(job1)
@@ -56,9 +44,7 @@ def test_autogression_configuration__add_job():
 
 def test_clear():
     """Should clear jobs container"""
-    arc = AutoRegressionConfiguration(
-        job_inputs=MagicMock(),
-    )
+    arc = AutoRegressionConfiguration()
     job1 = MagicMock()
     job1.name = "test"
     arc.add_job(job1)
@@ -74,9 +60,7 @@ def test_clear():
 def test_dump():
     """Should convert the configuration to json format"""
     filename = os.path.join(tempfile.gettempdir(), "jade-unit-test-arc.json")
-    arc = AutoRegressionConfiguration(
-        job_inputs=MagicMock(),
-    )
+    arc = AutoRegressionConfiguration()
     arc.dump(filename=filename)
     assert os.path.exists(filename)
     os.remove(filename)
@@ -84,9 +68,7 @@ def test_dump():
 
 def test_dumps():
     """Should call json to perform dumps"""
-    arc = AutoRegressionConfiguration(
-        job_inputs=MagicMock(),
-    )
+    arc = AutoRegressionConfiguration()
     string = arc.dumps()
     assert "demo" in string
     assert "AutoRegressionConfiguration" in string
@@ -100,10 +82,10 @@ def test_deserialize():
             tempfile.gettempdir(),
             "my_jobs_base_dir",
         ),
+        "format_version": JobConfiguration.FORMAT_VERSION,
     }
     arc = AutoRegressionConfiguration.deserialize(data)
     assert isinstance(arc, AutoRegressionConfiguration)
-    assert arc.inputs is None
     assert arc._jobs_directory == os.path.join(
         tempfile.gettempdir(),
         "my_jobs_base_dir",
@@ -112,9 +94,7 @@ def test_deserialize():
 
 def test_get_job():
     """Should return the job expected"""
-    arc = AutoRegressionConfiguration(
-        job_inputs=MagicMock(),
-    )
+    arc = AutoRegressionConfiguration()
     job1 = MagicMock()
     job1.name = "Job1"
     arc.add_job(job1)
@@ -127,19 +107,9 @@ def test_get_job():
     assert job == job1
 
 
-def test_get_parameters_class():
-    """Should return the AutoRegressionParameters class"""
-    arc = AutoRegressionConfiguration(
-        job_inputs=MagicMock(),
-    )
-    assert arc.get_parameters_class().__name__ == "AutoRegressionParameters"
-
-
 def test_iter_jobs():
     """Should iterate jobs in container"""
-    arc = AutoRegressionConfiguration(
-        job_inputs=MagicMock(),
-    )
+    arc = AutoRegressionConfiguration()
     job1 = MagicMock()
     job1.name = "Job1"
     arc.add_job(job1)
@@ -158,9 +128,7 @@ def test_iter_jobs():
 
 def test_list_jobs():
     """Should return a list of jobs"""
-    arc = AutoRegressionConfiguration(
-        job_inputs=MagicMock(),
-    )
+    arc = AutoRegressionConfiguration()
     job1 = MagicMock()
     job1.name = "Job1"
     arc.add_job(job1)
@@ -177,9 +145,7 @@ def test_reconfigure_jobs():
     """Should reconfigure with a list of jobs"""
     job1 = MagicMock()
     job1.name = "Job1"
-    arc = AutoRegressionConfiguration(
-        job_inputs=MagicMock(),
-    )
+    arc = AutoRegressionConfiguration()
     arc.add_job(job1)
 
     job2 = MagicMock()
@@ -199,9 +165,7 @@ def test_reconfigure_jobs():
 
 def test_remove_job():
     """Should remove job if job exists in container"""
-    arc = AutoRegressionConfiguration(
-        job_inputs=MagicMock(),
-    )
+    arc = AutoRegressionConfiguration()
     job1 = MagicMock()
     job1.name = "Job1"
     arc.add_job(job1)
@@ -217,7 +181,7 @@ def test_remove_job():
 #@patch("jade.extensions.demo.autoregression_configuration.AutoRegressionExecution")
 #def test_run_job(mock_job_execution_class):
 #    """Should run job using run method defined in AutoRegression class"""
-#    arc = AutoRegressionConfiguration(job_inputs=MagicMock())
+#    arc = AutoRegressionConfiguration()
 #    job1 = MagicMock()
 #    job1.name = "Job1"
 #    arc.add_job(job1)
@@ -232,14 +196,13 @@ def test_remove_job():
 
 def test_serialize():
     """Should create data for serialization"""
-    arc = AutoRegressionConfiguration(
-        job_inputs=MagicMock(),
-    )
+    arc = AutoRegressionConfiguration()
     data = arc.serialize()
 
     expected = {
-        "class": "AutoRegressionConfiguration",
-        "extension": "demo",
+        "configuration_class": "AutoRegressionConfiguration",
+        "configuration_module": "jade.extensions.demo.autoregression_configuration",
+        "format_version": "v0.2.0",
         "jobs_directory": None,
         "jobs": []
     }
@@ -248,9 +211,7 @@ def test_serialize():
 
 def test_serialize_jobs():
     """Should serialize a series of jobs"""
-    arc = AutoRegressionConfiguration(
-        job_inputs=MagicMock(),
-    )
+    arc = AutoRegressionConfiguration()
     job1 = AutoRegressionParameters(country="A", data="A.csv")
     arc.add_job(job1)
 
@@ -272,9 +233,7 @@ def test_serialize_jobs():
 
 def test_serialize_for_execution():
     """Serialize config data for efficient execution"""
-    arc = AutoRegressionConfiguration(
-        job_inputs=MagicMock(),
-    )
+    arc = AutoRegressionConfiguration()
     job1 = AutoRegressionParameters(country="AA", data="AA.csv")
     arc.add_job(job1)
 
@@ -297,9 +256,7 @@ def test_serialize_for_execution():
 
 def test_show_results(capsys):
     """Should print jobs to std.out"""
-    arc = AutoRegressionConfiguration(
-        job_inputs=MagicMock(),
-    )
+    arc = AutoRegressionConfiguration()
     job1 = AutoRegressionParameters(country="AAA", data="AA.csv")
     arc.add_job(job1)
 

--- a/tests/unit/extensions/demo/test_autoregression_configuration.py
+++ b/tests/unit/extensions/demo/test_autoregression_configuration.py
@@ -204,7 +204,8 @@ def test_serialize():
         "configuration_module": "jade.extensions.demo.autoregression_configuration",
         "format_version": "v0.2.0",
         "jobs_directory": None,
-        "jobs": []
+        "jobs": [],
+        "user_data": {},
     }
     assert data == expected
 

--- a/tests/unit/extensions/demo/test_autoregression_parameters.py
+++ b/tests/unit/extensions/demo/test_autoregression_parameters.py
@@ -34,7 +34,8 @@ def test_serialize():
     data = arp.serialize()
     expected = {
         "country": "united_states",
-        "data": "/path/to/data.csv"
+        "data": "/path/to/data.csv",
+        "extension": "demo",
     }
     assert data == expected
 

--- a/tests/unit/extensions/demo/test_cli.py
+++ b/tests/unit/extensions/demo/test_cli.py
@@ -18,7 +18,6 @@ def test_auto_config(test_data_dir):
     config = auto_config(inputs)
 
     assert isinstance(config, AutoRegressionConfiguration)
-    assert isinstance(config.inputs, AutoRegressionInputs)
     assert config.get_num_jobs() == 3
 
 

--- a/tests/unit/extensions/generic_command/test_generic_command.py
+++ b/tests/unit/extensions/generic_command/test_generic_command.py
@@ -48,7 +48,7 @@ def test_run_generic_commands(generic_command_fixture):
             f_out.write(command + "\n")
 
     inputs = GenericCommandInputs(TEST_FILENAME)
-    config = GenericCommandConfiguration(job_inputs=inputs)
+    config = GenericCommandConfiguration()
     for job_param in inputs.iter_jobs():
         config.add_job(job_param)
     assert config.get_num_jobs() == 2
@@ -71,8 +71,7 @@ def test_sorted_order(generic_command_fixture):
     with open(TEST_FILENAME, "w") as f_out:
         pass
 
-    inputs = GenericCommandInputs(TEST_FILENAME)
-    config = GenericCommandConfiguration(inputs)
+    config = GenericCommandConfiguration()
     num_jobs = 20
     for i in range(num_jobs):
         job = GenericCommandParameters("echo hello")
@@ -93,7 +92,7 @@ def test_job_order(generic_command_fixture):
             f_out.write(command + "\n")
 
     inputs = GenericCommandInputs(TEST_FILENAME)
-    config = GenericCommandConfiguration(job_inputs=inputs)
+    config = GenericCommandConfiguration()
     for job_param in inputs.iter_jobs():
         config.add_job(job_param)
     assert config.get_num_jobs() == num_jobs

--- a/tests/unit/jobs/test_dispatchable_job.py
+++ b/tests/unit/jobs/test_dispatchable_job.py
@@ -9,7 +9,9 @@ import time
 import mock
 import pytest
 
+from jade.common import RESULTS_DIR
 from jade.jobs.dispatchable_job import DispatchableJob
+from jade.jobs.results_aggregator import ResultsAggregator
 
 
 @pytest.fixture
@@ -20,7 +22,10 @@ def dispatchable_job():
     cmd = "echo 'Hello World'"
     output = os.path.join(tempfile.gettempdir(), "jade-test-dispatchable-job")
     os.makedirs(output, exist_ok=True)
-    results_file = os.path.join(output, "results_batch_0.csv")
+    os.makedirs(os.path.join(output, RESULTS_DIR), exist_ok=True)
+    results_file = os.path.join(output, "results.csv")
+    results_agg = ResultsAggregator(results_file)
+    results_agg.create_file()
     dispatchable_job = DispatchableJob(job, cmd, output, results_file)
     yield dispatchable_job
     shutil.rmtree(output)

--- a/tests/unit/jobs/test_results_aggregator.py
+++ b/tests/unit/jobs/test_results_aggregator.py
@@ -6,9 +6,8 @@ import tempfile
 
 import pytest
 
-from jade.common import get_results_temp_filename, RESULTS_DIR
-from jade.jobs.results_aggregator import ResultsAggregator, \
-    ResultsAggregatorSummary
+from jade.common import get_results_filename, RESULTS_DIR
+from jade.jobs.results_aggregator import ResultsAggregator
 from jade.result import Result
 
 
@@ -17,8 +16,7 @@ OUTPUT = os.path.join(tempfile.gettempdir(), "results-aggregator-output")
 
 @pytest.fixture
 def cleanup():
-    pytest.aggregator1 = None
-    pytest.aggregator2 = None
+    pytest.aggregator = None
     if os.path.exists(OUTPUT):
         shutil.rmtree(OUTPUT)
     yield
@@ -33,9 +31,7 @@ def create_result(index):
 
 def append(result):
     if int(result.name) % 2 == 0:
-        pytest.aggregator1.append_result(result)
-    else:
-        pytest.aggregator2.append_result(result)
+        pytest.aggregator.append_result(result)
 
 
 def test_results_aggregator(cleanup):
@@ -45,34 +41,19 @@ def test_results_aggregator(cleanup):
     os.makedirs(os.path.join(OUTPUT, RESULTS_DIR))
 
     results = [create_result(i) for i in range(100)]
-    batch1_file = get_results_temp_filename(OUTPUT, 1)
-    batch2_file = get_results_temp_filename(OUTPUT, 2)
-    pytest.aggregator1 = ResultsAggregator(batch1_file)
-    pytest.aggregator2 = ResultsAggregator(batch2_file)
-    pytest.aggregator1.create_file()
-    pytest.aggregator2.create_file()
-    assert os.path.exists(pytest.aggregator1._filename)
-    assert os.path.exists(pytest.aggregator2._filename)
+    batch_file = get_results_filename(OUTPUT)
+    pytest.aggregator = ResultsAggregator(batch_file)
+    pytest.aggregator.create_file()
+    assert os.path.exists(pytest.aggregator._filename)
 
     with ProcessPoolExecutor() as executor:
         executor.map(append, results)
 
-    final_results1 = pytest.aggregator1.get_results()
-    final_results1.sort(key=lambda x: int(x.name))
-    final_results2 = pytest.aggregator2.get_results()
-    final_results2.sort(key=lambda x: int(x.name))
+    final_results = pytest.aggregator.get_results()
+    final_results.sort(key=lambda x: int(x.name))
 
-    expected1 = [x for x in results if int(x.name) % 2 == 0]
-    expected2 = [x for x in results if int(x.name) % 2 != 0]
+    expected = [x for x in results if int(x.name) % 2 == 0]
 
-    assert final_results1 == expected1
-    assert final_results2 == expected2
+    assert final_results == expected
 
     results_dir = os.path.join(OUTPUT, RESULTS_DIR)
-    summary = ResultsAggregatorSummary(results_dir)
-    final_results = summary.get_results()
-    final_results.sort(key=lambda x: int(x.name))
-    assert final_results == results
-
-    summary.delete_files()
-    assert not [x for x in os.listdir(results_dir) if x.endswith(".csv")]


### PR DESCRIPTION
Each job in a configuration can now be from different extensions. The extension information now has to be stored in each job rather than at the top level.

This change requires a new format for the Jade registry as well as obviously the config file.
- The code will auto-convert the registry file, but you will lose non-Jade extensions. We can handle that for disco in its install script.
- The code will auto-convert generic_command jobs, but not any other type. It shouldn't be a big deal to regenerate disco files.

I changed the results aggregation process. Each job now updates a common results status file. This allows jobs to check the return codes of previous (blocking) jobs.