### PR TITLE
Change post-process config class_name to class

### DIFF
--- a/jade/cli/auto_config.py
+++ b/jade/cli/auto_config.py
@@ -54,7 +54,7 @@ def auto_config(
             job_post_process_config_file
         )
         JobPostProcess(module, class_name, data)  # ensure everything ok
-        job_post_process_config = {"module": module, "class_name": class_name, "data": data}
+        job_post_process_config = {"module": module, "class": class_name, "data": data}
     else:
         job_post_process_config = None
 


### PR DESCRIPTION
Tiny fix.

```bash
Traceback (most recent call last):
  File "/home/sabraham/.local/lib/python3.7/site-packages/jade/cli/run.py", line 101, in run
    class_name=config['job_post_process_config']['class'],
KeyError: 'class'
```