### PR TITLE
Add standalone CLI to collect stats

### DIFF
--- a/jade/cli/collect_stats.py
+++ b/jade/cli/collect_stats.py
@@ -1,0 +1,77 @@
+"""CLI to run jobs."""
+
+import logging
+import os
+import shutil
+import sys
+import time
+
+import click
+
+from jade.events import EventsSummary
+from jade.loggers import setup_logging
+from jade.resource_monitor import ResourceMonitor
+
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option(
+    "-d", "--duration",
+    default=None,
+    type=int,
+    show_default=True,
+    help="Total time to collect resource stats. Default is infinite."
+)
+@click.option(
+    "-f", "--force",
+    default=False,
+    is_flag=True,
+    show_default=True,
+    help="Delete output directory if it exists."
+)
+@click.option(
+    "-i", "--interval",
+    default=1,
+    type=int,
+    show_default=True,
+    help="Interval in seconds on which to collect resource stats."
+)
+@click.option(
+    "-o", "--output",
+    default="stats",
+    show_default=True,
+    help="Output directory."
+)
+def collect(duration, force, interval, output):
+    """Collect resource utilization stats."""
+    if os.path.exists(output):
+        if force:
+            shutil.rmtree(output)
+        else:
+            print(f"The directory {output} already exists. Delete it or run with --force")
+            sys.exit(1)
+
+    os.makedirs(output)
+    event_file = os.path.join(output, "stats_events.log")
+    setup_logging("event", event_file, console_level=logging.ERROR,
+                  file_level=logging.INFO)
+    monitor = ResourceMonitor("ResourceMonitor")
+    start_time = time.time()
+
+    show_cmd = f"jade stats show -o {output} [STATS]"
+    print(f"Collecting stats. When complete run '{show_cmd}' to view stats.")
+    try:
+        while True:
+            monitor.log_resource_stats()
+            time.sleep(interval)
+            if duration is not None and time.time() - start_time > duration:
+                print(f"Exceeded {duration} seconds. Exiting.")
+                EventsSummary(output)
+                break
+    except KeyboardInterrupt:
+        # TODO: This doesn't actually work. click catches KeyboardInterrupt.
+        # Need to prevent it from doing that.
+        # Then always call EventsSummary(output) at the end.
+        pass

--- a/jade/cli/stats.py
+++ b/jade/cli/stats.py
@@ -8,6 +8,7 @@ import sys
 import click
 from psutil._common import bytes2human
 
+from jade.cli.collect_stats import collect
 from jade.common import OUTPUT_DIR
 from jade.loggers import setup_logging
 from jade.events import EventsSummary
@@ -21,7 +22,7 @@ STATS = (
 
 @click.group()
 def stats():
-    """View stats from a run."""
+    """Collect new stats or view stats from an existing run."""
     setup_logging("stats", None)
 
 @click.argument("stats", nargs=-1)
@@ -111,5 +112,6 @@ def exec_time(output, human_readable):
 
 
 stats.add_command(bytes_consumed)
+stats.add_command(collect)
 stats.add_command(exec_time)
 stats.add_command(show)

--- a/jade/events.py
+++ b/jade/events.py
@@ -273,9 +273,10 @@ class EventsSummary:
         return self._events.get(name, [])
 
     def _handle_legacy_file(self, legacy_file):
-        for raw_event in load_data(legacy_file):
-            event = deserialize_event(raw_event)
-            self._events[event.name].append(event)
+        with open(legacy_file) as f_in:
+            for line in f_in:
+                event = deserialize_event(json.loads(line.strip()))
+                self._events[event.name].append(event)
 
         self._save_events_summary()
         os.remove(legacy_file)

--- a/tests/unit/test_resource_monitor.py
+++ b/tests/unit/test_resource_monitor.py
@@ -1,6 +1,7 @@
 
 import logging
 import os
+import shutil
 import tempfile
 
 from jade.events import EventsSummary, EVENT_NAME_CPU_STATS, \
@@ -53,3 +54,19 @@ def test_resource_stats():
         assert ret == 0
         for term in ("IOPS", "read_bytes", "bytes_recv", "idle"):
             assert term in output["stdout"]
+
+
+def test_collect_stats():
+    output_dir = os.path.join(tempfile.gettempdir(), "test-stats-output")
+    try:
+        ret = run_command(f"jade stats collect -i1 -o {output_dir} -d 1 -f")
+        assert ret == 0
+        cmd = f"jade stats show -o {output_dir} cpu disk mem net"
+        output = {}
+        ret = run_command(cmd, output=output)
+        assert ret == 0
+        for term in ("IOPS", "read_bytes", "bytes_recv", "idle"):
+            assert term in output["stdout"]
+    finally:
+        if os.path.exists(output_dir):
+            shutil.rmtree(output_dir)


### PR DESCRIPTION
This PR exposes the ResourceMonitor in a standalone CLI utility to allow simple collection of resource utilization stats.