### PR TITLE
Enhance resource monitor stats reporting

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -164,14 +164,14 @@ In order to view a summary of your jobs in a table:
     $ jade config show config.json
 
     Num jobs: 4
-    +-------+------+------------+
-    | index | name | blocked_by |
-    +-------+------+------------+
-    |   0   |  1   |            |
-    |   1   |  2   |     1      |
-    |   2   |  3   |     1      |
-    |   3   |  4   |    2, 3    |
-    +-------+------+------------+
+    +-------+------+----------------+---------------------------+
+    | index | name |    command     |   blocked_by (job names)  |
+    +-------+------+----------------+---------------------------+
+    |   0   |  1   | julia run.jl 1 |                           |
+    |   1   |  2   | julia run.jl 2 |            1              |
+    |   2   |  3   | julia run.jl 3 |            1              |
+    |   3   |  4   | julia run.jl 4 |           2, 3            |
+    +-------+------+----------------+---------------------------+
 
 CLI Execution
 =============
@@ -462,9 +462,10 @@ Jobs that timeout will be reported as missing.
 Debugging
 =========
 By default JADE generates report files that summarize what happened. Refer to
-``results.txt``, ``errors.txt``, and ``stats.txt``. The results file shows
-whether each job passed or failed.  The errors file shows unhandled errors
-that JADE detected as well as known errors that it parsed from log files.
+``results.txt``, ``errors.txt``, ``stats.txt``, and ``stats_summary.json``.
+The results file shows whether each job passed or failed.  The errors file
+shows unhandled errors that JADE detected as well as known errors that it
+parsed from log files.
 
 Here are the log files that JADE generates. Open these to dig deeper.
 
@@ -562,6 +563,7 @@ plots of the this data in ``<output-dir>/stats``.
 
 .. figure::  images/memory.png
 
+
 Use this CLI command to view textual tables after a run:
 
 .. code-block:: bash
@@ -571,8 +573,14 @@ Use this CLI command to view textual tables after a run:
     $ jade stats show disk
     $ jade stats show mem
     $ jade stats show net
+    $ jade stats show --summary-only
+    $ jade stats show --json-summary
 
 .. note:: Reads and writes to the Lustre filesystem on the HPC are not tracked.
+
+Use the ``--json-summary`` option if you want to programmatically analyze the
+average/minimum/maximum stats for each metric type. Note that these are
+auto-generated in the file ``<output-dir>/stats_summary.json``.
 
 The stats can also be provided as pandas.DataFrame objects. For example, here
 is how to view CPU stats for the node that ran the first batch:

--- a/jade/cli/show_status.py
+++ b/jade/cli/show_status.py
@@ -88,10 +88,12 @@ def show_status(output, job_status, verbose):
                     all_jobs_are_none = False
                     break
             if all_jobs_are_none:
-                logger.warn("HPC job statuses may be out-of-date.")
+                logger.warn("HPC job statuses may be out-of-date. Jobs may have timed-out.")
                 run_new_submitter = True
         else:
-            logger.error("Jobs are not complete but there no active HPC jobs.")
+            logger.error(
+                "Jobs are not complete but there no active HPC jobs. Jobs may have timed-out."
+            )
             run_new_submitter = True
         if run_new_submitter:
             try_submit_cmd = f"jade try-submit-jobs {output}"

--- a/jade/jobs/job_submitter.py
+++ b/jade/jobs/job_submitter.py
@@ -356,6 +356,7 @@ results_summary={self.get_results_summmary_report()}"""
         if include_stats:
             commands.append((f"jade stats plot -o {directory}", None))
             commands.append((f"jade stats show -o {directory}", "stats.txt"))
+            commands.append((f"jade stats show -o {directory} -j", "stats_summary.json"))
 
         reports = []
         for cmd in commands:
@@ -367,11 +368,13 @@ results_summary={self.get_results_summmary_report()}"""
             if cmd[1] is not None:
                 filename = os.path.join(directory, cmd[1])
                 with open(filename, "w") as f_out:
-                    f_out.write(cmd[0] + "\n\n")
+                    if "json" not in cmd[1]:
+                        f_out.write(cmd[0] + "\n\n")
                     f_out.write(output["stdout"])
                     reports.append(filename)
 
         logger.info("Generated reports %s.", " ".join(reports))
+
         return 0
 
     def _submit_to_hpc(self, cluster):

--- a/tests/unit/jobs/test_results_aggregator.py
+++ b/tests/unit/jobs/test_results_aggregator.py
@@ -1,11 +1,9 @@
-from concurrent.futures import ProcessPoolExecutor
 import os
 import shutil
 import tempfile
 
 import pytest
 
-from jade.common import get_temp_results_filename
 from jade.jobs.results_aggregator import ResultsAggregator
 from jade.result import Result
 
@@ -28,11 +26,6 @@ def create_result(index):
     return Result(str(index), index, "finished", 1.0 + index)
 
 
-def append(result):
-    if int(result.name) % 2 == 0:
-        pytest.aggregator.append_result(result)
-
-
 def test_results_aggregator(cleanup):
     """Test ResultsAggregator"""
     if os.path.exists(OUTPUT):
@@ -43,12 +36,11 @@ def test_results_aggregator(cleanup):
     pytest.aggregator = ResultsAggregator.create(OUTPUT)
     assert os.path.exists(pytest.aggregator._processed_filename)
 
-    with ProcessPoolExecutor() as executor:
-        executor.map(append, results)
+    for result in results:
+        if int(result.name) % 2 == 0:
+            pytest.aggregator.append_result(result)
 
     final_results = pytest.aggregator.process_results()
     final_results.sort(key=lambda x: int(x.name))
-
     expected = [x for x in results if int(x.name) % 2 == 0]
-
     assert final_results == expected


### PR DESCRIPTION
The stats CLI command has these new options:
- Report min and max values for every metric for every node.
- Option to dump the stat summaries to JSON

Changed `jade config show` to show the CLI command