### PR TITLE
use autosummary instead of autodoc for API reference

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,6 +23,7 @@ jobs:
       - name: build documentation
         run: |
           cd docs
+          make clean
           make html
       - name: deploy
         uses: peaceiris/actions-gh-pages@v3.6.1

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,8 @@ Thumbs.db
 *.egg-info
 __pycache__
 
-docs/_build
+docs/build
+docs/source/_autosummary
 .ipynb_checkpoints
 
 # Compiled Python files

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,7 +6,6 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
-BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -19,9 +18,9 @@ help:
 # TODO: define table dependencies on the Python Pydantic model files.
 
 %: Makefile
-	python make_model_tables.py -o $(BUILDDIR)/model_tables
 	rm -rf build
 	rm -rf source/_autosummary
+	python make_model_tables.py -o $(BUILDDIR)/model_tables
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 github: html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,7 +18,6 @@ help:
 # TODO: define table dependencies on the Python Pydantic model files.
 
 %: Makefile
-	rm -rf build
 	rm -rf source/_autosummary
 	python make_model_tables.py -o $(BUILDDIR)/model_tables
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,11 +20,11 @@ help:
 
 %: Makefile
 	python make_model_tables.py -o $(BUILDDIR)/model_tables
+	rm -rf build
+	rm -rf source/_autosummary
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 github: html
-	rm -rf source/jade
-	sphinx-apidoc -o source/jade ../jade
 	-git branch -D gh-pages
 	-git push origin --delete gh-pages
 	ghp-import -n -b gh-pages -m "Update documentation" ./build/html

--- a/docs/source/_templates/custom-class-template.rst
+++ b/docs/source/_templates/custom-class-template.rst
@@ -1,0 +1,34 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :show-inheritance:
+   :inherited-members:
+   :special-members: __call__, __add__, __mul__
+
+   {% block methods %}
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+      :nosignatures:
+   {% for item in methods %}
+      {%- if not item.startswith('_') %}
+      ~{{ name }}.{{ item }}
+      {%- endif -%}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/source/_templates/custom-class-template.rst
+++ b/docs/source/_templates/custom-class-template.rst
@@ -13,7 +13,6 @@
    .. rubric:: {{ _('Methods') }}
 
    .. autosummary::
-      :nosignatures:
    {% for item in methods %}
       {%- if not item.startswith('_') %}
       ~{{ name }}.{{ item }}

--- a/docs/source/_templates/custom-module-template.rst
+++ b/docs/source/_templates/custom-module-template.rst
@@ -8,7 +8,6 @@
 
    .. autosummary::
       :toctree:
-      :nosignatures:
    {% for item in attributes %}
       {{ item }}
    {%- endfor %}
@@ -21,7 +20,6 @@
 
    .. autosummary::
       :toctree:
-      :nosignatures:
    {% for item in functions %}
       {{ item }}
    {%- endfor %}
@@ -35,7 +33,6 @@
    .. autosummary::
       :toctree:
       :template: custom-class-template.rst
-      :nosignatures:
    {% for item in classes %}
       {{ item }}
    {%- endfor %}
@@ -48,7 +45,6 @@
 
    .. autosummary::
       :toctree:
-      :nosignatures:
    {% for item in exceptions %}
       {{ item }}
    {%- endfor %}
@@ -60,7 +56,6 @@
 .. autosummary::
    :toctree:
    :template: custom-module-template.rst
-   :nosignatures:
    :recursive:
 {% for item in modules %}
    {{ item }}

--- a/docs/source/_templates/custom-module-template.rst
+++ b/docs/source/_templates/custom-module-template.rst
@@ -1,0 +1,69 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Module attributes
+
+   .. autosummary::
+      :toctree:
+      :nosignatures:
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+      :toctree:
+      :nosignatures:
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+      :toctree:
+      :template: custom-class-template.rst
+      :nosignatures:
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exceptions %}
+   {% if exceptions %}
+   .. rubric:: {{ _('Exceptions') }}
+
+   .. autosummary::
+      :toctree:
+      :nosignatures:
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+{% block modules %}
+{% if modules %}
+.. autosummary::
+   :toctree:
+   :template: custom-module-template.rst
+   :nosignatures:
+   :recursive:
+{% for item in modules %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,6 @@
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+   :recursive:
+
+   jade

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,6 +35,7 @@ release = jade.version.__version__
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
     "sphinx.ext.coverage",
     "sphinx.ext.doctest",
     "sphinx.ext.githubpages",
@@ -93,6 +94,7 @@ html_static_path = ["_static"]
 
 # -- Extension configuration -------------------------------------------------
 
+autosummary_generate = True  # Turn on sphinx.ext.autosummary
 autoclass_content = "both"
 autodoc_member_order = "bysource"
 numpy_show_class_member = True

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,8 @@
-.. jade documentation master file, created by
-   sphinx-quickstart on Mon May  6 14:12:42 2019.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+.. toctree::
+   :hidden:
+
+   Home page <self>
+   API reference <_autosummary/jade>
 
 ******************
 JADE documentation


### PR DESCRIPTION
@daniel-thom I spent all day figuring out how to properly use sphinx autosummary to produce clean API reference docs. I've implemented it here if you want to give it a go