### PR TITLE
Disable distributed submitter

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -542,6 +542,28 @@ same jobs being run multiple times.
     $ rm <output-dir>/cluster_config.json.lock
     $ jade try-submit-jobs <output-dir>
 
+If you would like to avoid the possibility of this happening then you can
+pass ``--no-distributed-submitter`` to ``jade submit-jobs``. That will prevent
+each compute node from updating status or looking for unblocked jobs to submit.
+You will need to run the command ``jade try-submit-jobs`` yourself to do this.
+
+If you enable periodic resource utilization collection in this mode, be aware
+of the fact that once JADE detects that all jobs are complete it will
+aggregate the stats and generate plots in that process. This is
+resource-intensive and you may not want to run it on the login node. You can
+tell if this will occur beforehand by comparing the total number of jobs with 
+the number of completed jobs.
+
+.. code-block:: bash
+
+    # This will print the total number of jobs.
+    $ jade config show config.json
+
+    # This file lists the completed jobs and a header. Subtract one from this
+    # output to get the number of completed jobs.
+    $ wc -l output/results.csv
+
+
 Resource Monitoring
 ===================
 JADE optionally monitors CPU, disk, memory, and network utilization

--- a/jade/cli/common.py
+++ b/jade/cli/common.py
@@ -223,6 +223,14 @@ COMMON_SUBMITTER_OPTIONS = (
         default=SUBMITTER_PARAMS_DEFAULTS["node_shutdown_script"],
         help="Script to run on each after completing jobs (upload output files).",
     ),
+    click.option(
+        "-N",
+        "--no-distributed-submitter",
+        is_flag=True,
+        default=False,
+        show_default=True,
+        help="Disable the distributed submitter",
+    ),
 )
 
 
@@ -253,6 +261,7 @@ def make_submitter_params(
     time_based_batching=None,
     node_setup_script=None,
     node_shutdown_script=None,
+    no_distributed_submitter=None,
 ):
     """Returns an instance of SubmitterParams for use in a job submission."""
     if local:
@@ -313,6 +322,7 @@ def make_submitter_params(
         max_nodes=max_nodes,
         num_processes=num_processes,
         per_node_batch_size=per_node_batch_size,
+        distributed_submitter=not no_distributed_submitter,
         dry_run=dry_run,
         node_setup_script=node_setup_script,
         node_shutdown_script=node_shutdown_script,

--- a/jade/cli/config.py
+++ b/jade/cli/config.py
@@ -365,6 +365,7 @@ def submitter_params(
     time_based_batching=None,
     node_setup_script=None,
     node_shutdown_script=None,
+    no_distributed_submitter=None,
 ):
     """Create parameters for use in 'jade submit-jobs'."""
     params = make_submitter_params(
@@ -385,6 +386,7 @@ def submitter_params(
         time_based_batching=time_based_batching,
         node_setup_script=node_setup_script,
         node_shutdown_script=node_shutdown_script,
+        no_distributed_submitter=no_distributed_submitter,
     )
     # This converts enums to values.
     data = json.loads(params.json())

--- a/jade/cli/submit_jobs.py
+++ b/jade/cli/submit_jobs.py
@@ -64,6 +64,7 @@ def submit_jobs(
     node_setup_script=None,
     node_shutdown_script=None,
     submitter_params=None,
+    no_distributed_submitter=None,
 ):
     """Submits jobs for execution, locally or on HPC."""
     if os.path.exists(output):
@@ -97,6 +98,7 @@ def submit_jobs(
             time_based_batching=time_based_batching,
             node_setup_script=node_setup_script,
             node_shutdown_script=node_shutdown_script,
+            no_distributed_submitter=no_distributed_submitter,
         )
 
     if params.time_based_batching and params.num_processes is None:

--- a/jade/hpc/hpc_submitter.py
+++ b/jade/hpc/hpc_submitter.py
@@ -64,7 +64,11 @@ class HpcSubmitter:
         sing_params = submission_group.submitter_params.singularity_params
         if sing_params and sing_params.enabled:
             text += sing_params.setup_commands.split("\n")
-        command = f"jade-internal run-jobs {config_file} " f"--output={self._output}"
+        if submission_group.submitter_params.distributed_submitter:
+            dsub = "--distributed-submitter"
+        else:
+            dsub = "--no-distributed-submitter"
+        command = f"jade-internal run-jobs {config_file} --output={self._output} {dsub}"
         if submission_group.submitter_params.num_processes is not None:
             command += f" --num-processes={submission_group.submitter_params.num_processes}"
         if submission_group.submitter_params.verbose:

--- a/jade/jobs/job_configuration.py
+++ b/jade/jobs/job_configuration.py
@@ -238,8 +238,10 @@ class JobConfiguration(abc.ABC):
             "hpc_config",
             "per_node_batch_size",
             "singularity_params",
+            "distributed_submitter",
         )
         user_overrides = (
+            "distributed_submitter",
             "generate_reports",
             "resource_monitor_interval",
             "resource_monitor_type",

--- a/jade/models/submitter_params.py
+++ b/jade/models/submitter_params.py
@@ -58,7 +58,7 @@ class SubmitterParams(JadeBaseModel):
     )
     resource_monitor_type: Optional[ResourceMonitorType] = Field(
         title="resource_monitor_type",
-        description=f"Type of resource monitoring to perform. Options: {list(ResourceMonitorType)}",
+        description=f"Type of resource monitoring to perform. Options: {[x.value for x in ResourceMonitorType]}",
         default=ResourceMonitorType.AGGREGATION,
     )
     try_add_blocked_jobs: Optional[bool] = Field(
@@ -86,4 +86,9 @@ class SubmitterParams(JadeBaseModel):
         title="singularity_params",
         description="Singularity container parameters",
         default=None,
+    )
+    distributed_submitter: Optional[bool] = Field(
+        title="distributed_submitter",
+        description="Submit new jobs and update status on compute nodes.",
+        default=True,
     )

--- a/tests/integration/test_no_distributed_submitter.py
+++ b/tests/integration/test_no_distributed_submitter.py
@@ -1,0 +1,71 @@
+"""
+Unit tests for disabling the distributed submitter
+"""
+
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from jade.extensions.generic_command import GenericCommandInputs
+from jade.extensions.generic_command import GenericCommandConfiguration
+from jade.test_common import FAKE_HPC_CONFIG
+from jade.utils.subprocess_manager import check_run_command
+
+
+TEST_FILENAME = "test-inputs.txt"
+CONFIG_FILE = "test-config.json"
+OUTPUT = "test-output"
+SUBMIT_JOBS = f"jade submit-jobs -h {FAKE_HPC_CONFIG} -R none"
+TRY_SUBMIT_JOBS = "jade try-submit-jobs"
+WAIT = "jade wait -p 0.01"
+NUM_COMMANDS = 5
+
+
+@pytest.fixture
+def cleanup():
+    _do_cleanup()
+    commands = ['echo "hello world"'] * NUM_COMMANDS
+    with open(TEST_FILENAME, "w") as f_out:
+        for command in commands:
+            f_out.write(command + "\n")
+
+    inputs = GenericCommandInputs(TEST_FILENAME)
+    config = GenericCommandConfiguration.auto_config(inputs)
+    config.dump(CONFIG_FILE)
+    yield
+    _do_cleanup()
+
+
+def _do_cleanup():
+    for path in (TEST_FILENAME, CONFIG_FILE, OUTPUT):
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+        elif os.path.exists(path):
+            os.remove(path)
+
+
+def test_no_distributed_submitter(cleanup):
+    cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} --output={OUTPUT} -N --no-reports"
+    check_run_command(cmd)
+
+    results_file = Path(OUTPUT) / "results.csv"
+    processed_results_file = Path(OUTPUT) / "processed_results.csv"
+    all_jobs_complete = False
+    for _ in range(10):
+        lines = results_file.read_text().splitlines()
+        # The file has an extra line for the header.
+        if len(lines) == NUM_COMMANDS + 1:
+            all_jobs_complete = True
+            break
+        time.sleep(1)
+
+    assert all_jobs_complete
+    assert len(processed_results_file.read_text().splitlines()) == 1
+
+    check_run_command(f"{TRY_SUBMIT_JOBS} {OUTPUT}")
+    check_run_command(f"{WAIT} --output={OUTPUT}")
+    assert len(processed_results_file.read_text().splitlines()) == NUM_COMMANDS + 1
+    assert len(results_file.read_text().splitlines()) == 1


### PR DESCRIPTION
One of users hit an issue last week where a walltime timeout occurred while the compute node was holding the cluster lock. This resulted in a deadlock. In this case the user was not relying on managing blocked jobs. A simple way to prevent this from happening is to disable the actions on the compute nodes. The user can manually check status of the jobs (and trigger Jade updates) when they want.

I also added some timings of these actions. I suspect that they are taking longer than I expect, perhaps when there are hundreds of compute nodes running at the same time (high lock contention).

Note that this includes commits from #52. We will need to merge that first.