### PR TITLE
Add a shuffle-jobs option

### DIFF
--- a/jade/cli/config.py
+++ b/jade/cli/config.py
@@ -53,6 +53,20 @@ def config():
     help="estimated minutes per job.",
 )
 @click.option(
+    "--shuffle/--no-shuffle",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Shuffle order of jobs.",
+)
+@click.option(
+    "--strip-whitespace/--no-strip-whitespace",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Strip whitespace in file.",
+)
+@click.option(
     "-v",
     "--verbose",
     is_flag=True,
@@ -60,7 +74,15 @@ def config():
     show_default=True,
     help="Enable verbose log output.",
 )
-def create(filename, config_file, cancel_on_blocking_job_failure, minutes_per_job, verbose):
+def create(
+    filename,
+    config_file,
+    cancel_on_blocking_job_failure,
+    minutes_per_job,
+    shuffle,
+    strip_whitespace,
+    verbose,
+):
     """Create a config file from a filename with a list of executable commands."""
     level = logging.DEBUG if verbose else logging.WARNING
     setup_logging("auto_config", None, console_level=level)
@@ -70,8 +92,11 @@ def create(filename, config_file, cancel_on_blocking_job_failure, minutes_per_jo
         cancel_on_blocking_job_failure=cancel_on_blocking_job_failure,
         minutes_per_job=minutes_per_job,
     )
+    if shuffle:
+        config.shuffle_jobs()
     print(f"Created configuration with {config.get_num_jobs()} jobs.")
-    config.dump(config_file)
+    indent = None if strip_whitespace else 2
+    config.dump(config_file, indent=indent)
     print(f"Dumped configuration to {config_file}.\n")
 
 

--- a/jade/jobs/job_configuration.py
+++ b/jade/jobs/job_configuration.py
@@ -610,6 +610,10 @@ class JobConfiguration(abc.ABC):
 
         """
 
+    def shuffle_jobs(self):
+        """Shuffle the job order."""
+        self._jobs.shuffle()
+
     def show_jobs(self):
         """Show the configured jobs."""
         for job in self.iter_jobs():

--- a/jade/jobs/job_container_by_key.py
+++ b/jade/jobs/job_container_by_key.py
@@ -78,3 +78,11 @@ class JobContainerByKey(JobContainerInterface):
             return [self._jobs[x] for x in keys]
 
         return list(self)
+
+    def shuffle(self):
+        keys = list(self._jobs.keys())
+        random.shuffle(keys)
+        new_jobs = {}
+        for key in keys:
+            new_jobs[key] = self._jobs.pop(key)
+        self._jobs = new_jobs

--- a/jade/jobs/job_container_by_name.py
+++ b/jade/jobs/job_container_by_name.py
@@ -1,6 +1,7 @@
 """Implements a container for jobs represented by a key."""
 
 import logging
+import random
 
 from jade.exceptions import InvalidParameter
 from jade.jobs.job_container_interface import JobContainerInterface
@@ -48,3 +49,11 @@ class JobContainerByName(JobContainerInterface):
             return [self._jobs[x] for x in names]
 
         return list(self)
+
+    def shuffle(self):
+        names = list(self._jobs.keys())
+        random.shuffle(names)
+        new_jobs = {}
+        for name in names:
+            new_jobs[name] = self._jobs.pop(name)
+        self._jobs = new_jobs

--- a/jade/jobs/job_container_interface.py
+++ b/jade/jobs/job_container_interface.py
@@ -72,3 +72,7 @@ class JobContainerInterface(abc.ABC):
         job : JobParametersInterface
 
         """
+
+    @abc.abstractmethod
+    def shuffle(self):
+        """Shuffle the order of the jobs."""

--- a/tests/unit/jobs/test_job_configuration.py
+++ b/tests/unit/jobs/test_job_configuration.py
@@ -67,3 +67,19 @@ def test_job_configuration__check_job_dependencies_estimate(job_fixture):
     params = SubmitterParams(hpc_config=hpc_config, per_node_batch_size=0)
     with pytest.raises(InvalidConfiguration):
         config.check_job_dependencies(params)
+
+
+def test_job_configuration__shuffle_jobs(job_fixture):
+    num_jobs = 10
+    with open(TEST_FILENAME, "w") as f_out:
+        for i in range(num_jobs):
+            f_out.write("echo hello world\n")
+
+    inputs = GenericCommandInputs(TEST_FILENAME)
+    config = GenericCommandConfiguration(job_inputs=inputs)
+    for job_param in inputs.iter_jobs():
+        config.add_job(job_param)
+    assert config.get_num_jobs() == num_jobs
+    assert [x.name for x in config.iter_jobs()] == [str(x) for x in range(1, num_jobs + 1)]
+    config.shuffle_jobs()
+    assert [x.name for x in config.iter_jobs()] != [str(x) for x in range(1, num_jobs + 1)]


### PR DESCRIPTION
In some cases jobs across the configuration had varying runtimes. The
jobs that were of similar runtimes were bunched together. This resulted
in unevenly-sized node batches. Some nodes completed all jobs in an
hour; some nodes hit walltime timeouts. Shuffling the jobs would have
produced more even batches.

Note that this includes #56. The review will be simpler once that branch is merged.