### PR TITLE
Fix result collection on multi-node jobs

### DIFF
--- a/jade/hpc/fake_manager.py
+++ b/jade/hpc/fake_manager.py
@@ -38,7 +38,7 @@ class FakeManager(HpcManagerInterface):
         self._config = config
 
     def am_i_manager(self):
-        assert False
+        return True
 
     def cancel_job(self, job_id):
         return 0

--- a/jade/jobs/job_runner.py
+++ b/jade/jobs/job_runner.py
@@ -159,6 +159,7 @@ class JobRunner(JobManagerBase):
                 ),
                 self._output,
                 self._batch_id,
+                self._intf.am_i_manager(),
             )
             jobs.append(djob)
 

--- a/tests/unit/jobs/test_async_cli_command.py
+++ b/tests/unit/jobs/test_async_cli_command.py
@@ -24,7 +24,7 @@ def async_cmd():
     os.makedirs(output, exist_ok=True)
     os.makedirs(os.path.join(output, RESULTS_DIR), exist_ok=True)
     ResultsAggregator.create(output)
-    cmd = AsyncCliCommand(job, cmd, output, 1)
+    cmd = AsyncCliCommand(job, cmd, output, 1, True)
     yield cmd
     shutil.rmtree(output)
 


### PR DESCRIPTION
Results were being collected once per node, which resulted in erroneous reporting.