### PR TITLE
  Add pipeline creation option

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
-        python-version: 3.8
+        python-version: 3.9
     - name: Build and upload conda package
       shell: bash -l {0}
       env:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,7 +12,7 @@ jobs:
       - name: select python version
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -10,10 +10,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
           # Tests using the FakeManager don't work on Windows because they use bash.
           #os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8]
-        include:
-          - os: ubuntu-latest
-            python-version: 3.7
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -42,13 +42,18 @@ and CPU.
     $ jade show-status -o <output-dir>
 
 
+- *How can I tell Jade to run one final post-processing job once all other jobs have finished?*
+
+Define the ``teardown_command`` parameter in ``config.json``. Don't bother with defining job dependencies.
+
+
 - *I submitted 10 sets of jobs at the same time. How can I distinguish my jobs in the output of squeue?*
 
 Customize the ``job_prefix`` field in ``hpc_config.toml``. By default it is ``job`` and so you will see
 ``job_batch_1``, ``job_batch_2``, etc, in ``squeue``.
 
 
-- *Can I check what will be submitted without actually starting the jobs?*
+- *Can I check what will be submitted, and in which batch, without actually starting the jobs?*
 
 Yes. There is a ``dry run`` feature.
 

--- a/docs/source/pipeline.rst
+++ b/docs/source/pipeline.rst
@@ -29,7 +29,13 @@ order to provide information about completed stages and their outputs:
 
 .. code-block:: bash
 
-    $ jade pipeline create batch1-auto-config.sh batch2-auto-config.sh -c pipeline.toml
+    $ jade pipeline create -a batch1-auto-config.sh -a batch2-auto-config.sh -c pipeline.toml
+
+Alternatively, if your config files are known beforehand, you can specify them directly.
+
+.. code-block:: bash
+
+    $ jade pipeline create -f config_stage1.json -f config_stage2.json -c pipeline.toml
 
 Customize the config
 ====================
@@ -142,7 +148,7 @@ Let's create the pipeline and submit it for execution.
 
 .. code-block:: bash
 
-    $ jade pipeline create ./jade/extensions/demo/create_demo_config.sh ./jade/extensions/demo/create_merge_pred_gdp.py
+    $ jade pipeline create -a ./jade/extensions/demo/create_demo_config.sh -a ./jade/extensions/demo/create_merge_pred_gdp.py
     Created pipeline config file pipeline.toml
 
     $ jade pipeline submit pipeline.toml

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -378,6 +378,8 @@ The following environment variable is available when these scripts are executed:
 
 - ``JADE_RUNTIME_OUTPUT``: output directory passed to ``jade submit-jobs``
 
+.. note:: In ``jade resubmit-jobs`` Jade will not rerun the setup command. It will re-run the teardown command.
+
 Note that the output directory contains a copy of ``config.json`` in case you need to access
 information from it.
 

--- a/jade/jobs/cluster.py
+++ b/jade/jobs/cluster.py
@@ -427,7 +427,7 @@ class Cluster:
             if job.state != JobState.DONE:
                 assert (
                     self._config.completed_jobs != self._config.num_jobs
-                ), "completed={self._config.completed_jobs}"
+                ), f"completed={self._config.completed_jobs}"
                 return False
 
         assert (

--- a/jade/jobs/job_queue.py
+++ b/jade/jobs/job_queue.py
@@ -10,8 +10,8 @@ from jade.enums import Status
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_POLL_INTERVAL = 1
-DEFAULT_MONITOR_INTERVAL = 30
+DEFAULT_POLL_INTERVAL = 10
+DEFAULT_MONITOR_INTERVAL = 10
 
 
 class JobQueue:
@@ -69,6 +69,8 @@ class JobQueue:
         else:
             self._monitor_interval = monitor_interval
 
+        if self._monitor_interval is not None:
+            self._poll_interval = min(self._poll_interval, self._monitor_interval)
         logger.debug(
             "queue_depth=%s poll_interval=%s monitor_interval=%s",
             self._queue_depth,
@@ -134,7 +136,7 @@ class JobQueue:
         return len(self._outstanding_jobs) >= self._queue_depth
 
     def _handle_monitor_func(self, force=False):
-        if self._monitor_func is None:
+        if self._monitor_func is None or self._monitor_interval is None:
             return
 
         needs_monitor = False

--- a/jade/jobs/job_runner.py
+++ b/jade/jobs/job_runner.py
@@ -238,6 +238,7 @@ class JobRunner(JobManagerBase):
             max_queue_depth=num_workers,
             monitor_func=monitor_func,
             monitor_interval=resource_monitor_interval,
+            poll_interval=group.submitter_params.poll_interval,
         )
 
         logger.info("Jobs are complete. count=%s", num_jobs)

--- a/jade/models/pipeline.py
+++ b/jade/models/pipeline.py
@@ -10,7 +10,7 @@ from jade.models import JadeBaseModel, SubmitterParams
 class PipelineStage(JadeBaseModel):
     """Describes one stage of a pipeline."""
 
-    auto_config_cmd: str = Field(
+    auto_config_cmd: Optional[str] = Field(
         title="auto_config_cmd",
         description="command used to create the JADE configuration",
     )

--- a/jade/models/submitter_params.py
+++ b/jade/models/submitter_params.py
@@ -52,13 +52,14 @@ class SubmitterParams(JadeBaseModel):
     poll_interval: int = Field(
         title="poll_interval",
         description="Interval in seconds on which to poll jobs for status",
-        default=60,
+        default=10,
     )
-    resource_monitor_interval: int = Field(
+    resource_monitor_interval: Optional[int] = Field(
         title="resource_monitor_interval",
-        description="Interval in seconds on which to collect resource stats. If None, aggregate"
+        description="Interval in seconds on which to collect resource stats. Disable monitoring "
+        "by setting this to None/null."
         "summaries of stats.",
-        default=1,
+        default=10,
     )
     resource_monitor_type: ResourceMonitorType = Field(
         title="resource_monitor_type",

--- a/jade/resource_monitor.py
+++ b/jade/resource_monitor.py
@@ -153,6 +153,10 @@ class ResourceMonitorAggregator:
             Directory in which to record the results.
 
         """
+        if self._count == 0:
+            logger.info("Resource monitoring was disabled")
+            return
+
         for resource_type, stat_dict in self._summaries["sum"].items():
             for stat_name, val in stat_dict.items():
                 self._summaries["average"][resource_type][stat_name] = val / self._count

--- a/tests/integration/test_cancel_on_failure.py
+++ b/tests/integration/test_cancel_on_failure.py
@@ -69,7 +69,7 @@ def test_cancel_on_failure_detect_by_submitter(cleanup):
     cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} --output={OUTPUT} -n2 -b2"
     ret = run_command(cmd)
     assert ret == 0
-    ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.01 -t 2")
+    ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.1 -t 2")
     assert ret == 0
 
     summary = ResultsSummary(OUTPUT)
@@ -88,7 +88,7 @@ def test_cancel_on_failure_detect_by_runner(cleanup):
     cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} --output={OUTPUT} -n2 -b8"
     ret = run_command(cmd)
     assert ret == 0
-    ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.01 -t 2")
+    ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.1 -t 2")
     assert ret == 0
 
     summary = ResultsSummary(OUTPUT)

--- a/tests/integration/test_estimated_runtime.py
+++ b/tests/integration/test_estimated_runtime.py
@@ -72,9 +72,9 @@ def test_estimated_run_time(cleanup):
     # 10-minute jobs
     # Each of 4 cores can each complete 24 jobs. 4 * 24 = 96 jobs
     # 100 jobs will take two batches.
-    cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} --output={OUTPUT} -t -n2 -q4"
+    cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} --output={OUTPUT} -p 0.1 -t -n2 -q4"
     check_run_command(cmd)
-    check_run_command(f"{WAIT} --output={OUTPUT} -p 0.01 -t2")
+    check_run_command(f"{WAIT} --output={OUTPUT} -p 0.1 -t2")
 
     batch_config_1 = Path(OUTPUT) / "config_batch_1.json"
     assert os.path.exists(batch_config_1)

--- a/tests/integration/test_no_distributed_submitter.py
+++ b/tests/integration/test_no_distributed_submitter.py
@@ -21,7 +21,7 @@ CONFIG_FILE = "test-config.json"
 OUTPUT = "test-output"
 SUBMIT_JOBS = f"jade submit-jobs -h {FAKE_HPC_CONFIG} -R none"
 TRY_SUBMIT_JOBS = "jade try-submit-jobs"
-WAIT = "jade wait -p 0.01"
+WAIT = "jade wait -p 0.1"
 NUM_COMMANDS = 5
 
 
@@ -49,7 +49,7 @@ def _do_cleanup():
 
 
 def test_no_distributed_submitter(cleanup):
-    cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} --output={OUTPUT} -N --no-reports"
+    cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} --output={OUTPUT} -p 0.1 -N --no-reports"
     check_run_command(cmd)
 
     results_file = Path(OUTPUT) / RESULTS_DIR / "results_batch_1.csv"
@@ -68,6 +68,6 @@ def test_no_distributed_submitter(cleanup):
     assert len(processed_results_file.read_text().splitlines()) == 1
 
     check_run_command(f"{TRY_SUBMIT_JOBS} {OUTPUT}")
-    check_run_command(f"{WAIT} --output={OUTPUT} -p 0.01 -t2")
+    check_run_command(f"{WAIT} --output={OUTPUT} -p 0.1 -t2")
     assert len(processed_results_file.read_text().splitlines()) == NUM_COMMANDS + 1
     assert not results_file.exists()

--- a/tests/integration/test_resubmit_jobs.py
+++ b/tests/integration/test_resubmit_jobs.py
@@ -59,9 +59,9 @@ def _do_cleanup():
 
 
 def test_resubmit_successful(cleanup):
-    cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} --output={OUTPUT}"
+    cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} --output={OUTPUT} -p 0.1"
     check_run_command(cmd)
-    check_run_command(f"{WAIT} --output={OUTPUT} -p 0.01 -t2")
+    check_run_command(f"{WAIT} --output={OUTPUT} -p 0.1 -t2")
     summary = ResultsSummary(OUTPUT)
     assert len(summary.get_failed_results()) == 0
     assert len(summary.get_successful_results()) == NUM_COMMANDS
@@ -73,7 +73,7 @@ def test_resubmit_successful(cleanup):
     dump_data(groups, SG_FILE)
 
     check_run_command(f"{RESUBMIT_JOBS} {OUTPUT} -s {SG_FILE} --successful")
-    check_run_command(f"{WAIT} --output={OUTPUT} -p 0.01")
+    check_run_command(f"{WAIT} --output={OUTPUT} -p 0.1")
     summary = ResultsSummary(OUTPUT)
     assert len(summary.get_failed_results()) == 0
     assert len(summary.get_successful_results()) == NUM_COMMANDS
@@ -84,10 +84,10 @@ def test_resubmit_successful(cleanup):
 
 
 def test_resubmit_failed(cleanup):
-    cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} --output={OUTPUT}"
+    cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} --output={OUTPUT} -p 0.1"
     ret = run_command(cmd)
     assert ret == 0
-    ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.01")
+    ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.1")
     assert ret == 0
 
     agg = ResultsAggregator.load(OUTPUT)
@@ -111,7 +111,7 @@ def test_resubmit_failed(cleanup):
 
     ret = run_command(f"{RESUBMIT_JOBS} {OUTPUT}")
     assert ret == 0
-    ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.01")
+    ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.1")
     assert ret == 0
 
     summary = ResultsSummary(OUTPUT)
@@ -119,10 +119,10 @@ def test_resubmit_failed(cleanup):
 
 
 def test_resubmit_missing(cleanup):
-    cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} --output={OUTPUT}"
+    cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} --output={OUTPUT} -p 0.1"
     ret = run_command(cmd)
     assert ret == 0
-    ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.01")
+    ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.1")
     assert ret == 0
 
     agg = ResultsAggregator.load(OUTPUT)
@@ -147,7 +147,7 @@ def test_resubmit_missing(cleanup):
 
     ret = run_command(f"{RESUBMIT_JOBS} {OUTPUT}")
     assert ret == 0
-    ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.01")
+    ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.1")
     assert ret == 0
 
     summary = ResultsSummary(OUTPUT)
@@ -177,7 +177,7 @@ def test_resubmit_with_blocking_jobs(basic_setup):
     cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} --output={OUTPUT}"
     ret = run_command(cmd)
     assert ret == 0
-    ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.01")
+    ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.1")
     assert ret == 0
 
     agg = ResultsAggregator.load(OUTPUT)
@@ -216,7 +216,7 @@ def test_resubmit_with_blocking_jobs(basic_setup):
 
     ret = run_command(f"{RESUBMIT_JOBS} {OUTPUT}")
     assert ret == 0
-    ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.01")
+    ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.1")
     assert ret == 0
 
     summary = ResultsSummary(OUTPUT)

--- a/tests/integration/test_try_add_blocked_jobs.py
+++ b/tests/integration/test_try_add_blocked_jobs.py
@@ -51,7 +51,7 @@ def test_try_add_blocked_jobs(cleanup):
         cmd = f"{SUBMIT_JOBS} {CONFIG_FILE} --output={OUTPUT} -h {FAKE_HPC_CONFIG} -p 0.1 {option}"
         ret = run_command(cmd)
         assert ret == 0
-        ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.01")
+        ret = run_command(f"{WAIT} --output={OUTPUT} -p 0.1")
         assert ret == 0
         events_summary = EventsSummary(OUTPUT, preload=True)
         submit_events = events_summary.list_events(EVENT_NAME_HPC_SUBMIT)

--- a/tests/unit/extensions/generic_command/test_generic_command.py
+++ b/tests/unit/extensions/generic_command/test_generic_command.py
@@ -76,7 +76,7 @@ def test_run_generic_commands(generic_command_fixture):
 
     for cmd in cmds:
         check_run_command(cmd)
-        check_run_command(f"{WAIT} --output={OUTPUT} --poll-interval=0.01 -t2")
+        check_run_command(f"{WAIT} --output={OUTPUT} --poll-interval=0.1 -t2")
 
     assert list(Path(OUTPUT).glob("*.sh"))
     assert (Path(OUTPUT) / "jade_setup.txt").read_text().strip() == "setup"
@@ -151,7 +151,7 @@ def test_job_order(generic_command_fixture):
         "--num-parallel-processes-per-node=10"
     )
     check_run_command(cmd)
-    check_run_command(f"{WAIT} --output={OUTPUT} --poll-interval=0.01")
+    check_run_command(f"{WAIT} --output={OUTPUT} --poll-interval=0.1")
 
     result_summary = ResultsSummary(OUTPUT)
     results = result_summary.list_results()


### PR DESCRIPTION
This change allows the user to specify pipeline configurations with existing Jade config files. It is also a breaking change for existing workflows. The CLI creation command requires a minor change.