### PR TITLE
Regenerate events and stats on resubmit-jobs

### DIFF
--- a/jade/cli/collect_stats.py
+++ b/jade/cli/collect_stats.py
@@ -1,4 +1,4 @@
-"""CLI to run jobs."""
+"""CLI to collect and process resource stats."""
 
 import logging
 import os

--- a/jade/cli/resubmit_jobs.py
+++ b/jade/cli/resubmit_jobs.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import click
 
-from jade.common import CONFIG_FILE
+from jade.common import CONFIG_FILE, EVENTS_DIR
 from jade.enums import Status
 from jade.jobs.cluster import Cluster
 from jade.jobs.job_configuration_factory import create_config_from_file
@@ -111,6 +111,12 @@ def resubmit_jobs(output, failed, missing, successful, submission_groups_file, v
     updated_blocking_jobs_by_name = _update_with_blocking_jobs(jobs_to_resubmit, output)
     _reset_results(output, jobs_to_resubmit)
     cluster.prepare_for_resubmission(jobs_to_resubmit, updated_blocking_jobs_by_name)
+    events_dir = Path(output) / EVENTS_DIR
+    for path in list(events_dir.iterdir()):
+        # These files will get regenerated. It would be better to only generate events for new
+        # compute node batches, but the code in events.py doesn't support that.
+        # TODO
+        path.unlink()
 
     ret = 1
     try:

--- a/jade/events.py
+++ b/jade/events.py
@@ -3,11 +3,9 @@ This module contains StructuredLogEvent and EventSummary classes.
 """
 
 from collections import defaultdict
-import copy
 import json
 import logging
 import os
-import re
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -15,12 +13,10 @@ from pathlib import Path
 import pandas as pd
 from prettytable import PrettyTable
 
-from jade.common import JOBS_OUTPUT_DIR
+from jade.common import JOBS_OUTPUT_DIR, EVENTS_DIR
 from jade.exceptions import InvalidConfiguration
 from jade.utils.utils import dump_data, load_data
 
-
-EVENT_DIR = "events"
 
 EVENTS_FILENAME = "events.json"
 
@@ -223,7 +219,7 @@ class EventsSummary:
         self._optimize_resource_stats = optimize_resoure_stats
         self._events = defaultdict(list)
         self._output_dir = output_dir
-        self._event_dir = Path(output_dir) / EVENT_DIR
+        self._event_dir = Path(output_dir) / EVENTS_DIR
         self._event_dir.mkdir(exist_ok=True)
         self._job_outputs_dir = os.path.join(output_dir, JOBS_OUTPUT_DIR)
         event_files = list(self._event_dir.iterdir())

--- a/jade/resource_monitor.py
+++ b/jade/resource_monitor.py
@@ -288,7 +288,7 @@ class ResourceMonitorAggregator:
     def update_resource_stats(self, ids=None):
         """Update resource stats information as structured job events for the current interval."""
         cur_stats = self._get_stats()
-        for resource_type, stat_dict in self._last_stats.items():
+        for resource_type, stat_dict in cur_stats.items():
             for stat_name, val in stat_dict.items():
                 if val > self._summaries["maximum"][resource_type][stat_name]:
                     self._summaries["maximum"][resource_type][stat_name] = val


### PR DESCRIPTION
This PR fixes a bug where events and resource stats were not being updated to reflect new compute node batches when `jade resubmit-jobs` was called.